### PR TITLE
Fix: Introduces optional handling of volumes and image_pull_secrets in scenarios where neither is needed.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "oci_container_instances_container_instance" "container_instance" {
     arguments = try(var.container_instance[count.index]["arguments"], null)
 
     dynamic "volume_mounts" {
-      for_each = var.container_instance[count.index]["volumes"]
+      for_each = try(var.container_instance[count.index]["volumes"], {})
       content {
         volume_name = volume_mounts.key
         mount_path  = volume_mounts.value.path
@@ -53,7 +53,7 @@ resource "oci_container_instances_container_instance" "container_instance" {
   }
 
   dynamic "image_pull_secrets" {
-    for_each = var.image_pull_secrets
+    for_each = try(var.image_pull_secrets, {})
     content {
       registry_endpoint = image_pull_secrets.value.registry_endpoint
       secret_type       = image_pull_secrets.value.secret_type
@@ -65,7 +65,7 @@ resource "oci_container_instances_container_instance" "container_instance" {
   }
 
   dynamic "volumes" {
-    for_each = var.container_instance[count.index]["volumes"]
+    for_each = try(var.container_instance[count.index]["volumes"], {})
     content {
       name          = volumes.key
       volume_type   = volumes.value.volume_type

--- a/variables.tf
+++ b/variables.tf
@@ -12,5 +12,5 @@ variable "container_instance" {}
 
 variable "image_pull_secrets" {
   type    = map(any)
-  default = null
+  default = {}
 }


### PR DESCRIPTION
In our case we're starting an image from docker.io without the need to mount any volumes or provide pull secrets, like:
```
module "cf-built-in-webserver" {
    source = "../../../acf_resource_container_instance"

    compartment_ocid = var.compartment_ocid
    subnet_id  = var.subnet_id
    container_instance = [
        {
            container_name = "tunnel"
            container_image_url = "docker.io/cloudflare/cloudflared:2023.5.1"
            command = [
                "cloudflared",
                "--no-autoupdate"
            ]
            arguments = [
                "tunnel",
                "run"
            ]
            env_variables = {
                TUNNEL_TOKEN = var.tunnel_token
                TUNNEL_HELLO_WORLD = true
            }
            shape = "CI.Standard.E4.Flex"
            cpu = 1
            mem = 4
        }
    ]
}
```

@ctxch Please review whether https://github.com/avaloqcloud/acf_svc_capi/tree/feature/amiws-tf-definition still works with this pull request / branch, I did rudimentary testing but just to be sure.

Thanks
